### PR TITLE
Updating PHP dependency

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,11 +1,15 @@
-name: Check code style format
+name: Code Style
 
 on: [push, pull_request]
 
 jobs:
   style:
-    name: "PHP CS Fixer"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: 'ubuntu-latest'
+        php: ['7.1', '7.3', '8.0']
+    name: "PHP CS Fixer - PHP v${{ matrix.php }}"
 
     steps:
       - name: Checkout code
@@ -14,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: 'ubuntu-latest'
+        os: ['ubuntu-latest']
         php: ['7.1', '7.3', '8.0']
     name: "PHP CS Fixer - PHP v${{ matrix.php }}"
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.1|^8.0",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "autoload": {


### PR DESCRIPTION
This PR updates the PHP dependency in the `composer.json` and also updates the GitHub actions to allow testing running the PHP CS Fixer on PHP versions 7.1, 7.3 (lts) and 8.0.